### PR TITLE
Add Distributions 0.24 and update workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,6 @@ jobs:
         arch:
           - x64
           - x86
-        coverage: [false]
         exclude:
           - os: macOS-latest
             arch: x86
@@ -29,7 +28,6 @@ jobs:
           - os: ubuntu-latest
             version: '1.0'
             arch: x64
-            coverage: false
           - os: ubuntu-latest
             version: '1'
             arch: x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,8 +25,8 @@ jobs:
           - os: macOS-latest
             arch: x86
         include:
-          - os: ubuntu-latest
-            version: '1.0'
+          - version: '1.0'
+            os: ubuntu-latest
             arch: x64
           - os: ubuntu-latest
             version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
+    strategy:
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+          - x86
+        coverage: [false]
+        exclude:
+          - os: macOS-latest
+            arch: x86
+        include:
+          - os: ubuntu-latest
+            version: '1.0'
+            arch: x64
+            coverage: false
+          - os: ubuntu-latest
+            version: '1'
+            arch: x64
+            coverage: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.coverage
+      - uses: codecov/codecov-action@v1
+        if: matrix.coverage
+        with:
+          file: lcov.info
+      - uses: coverallsapp/github-action@master
+        if: matrix.coverage
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,5 +12,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}  # optional
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,11 +1,15 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedVI"
 uuid = "b5ca4192-6429-45e5-a2d9-87aec30a685c"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
@@ -18,7 +18,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [compat]
 Bijectors = "0.4.0, 0.5, 0.6, 0.7, 0.8"
-Distributions = "0.21, 0.22, 0.23"
+Distributions = "0.21, 0.22, 0.23, 0.24"
 DistributionsAD = "0.2, 0.3, 0.4, 0.5, 0.6"
 DocStringExtensions = "0.8"
 ForwardDiff = "0.10.3"


### PR DESCRIPTION
This PR adds Distributions 0.24 and sets up CI tests.

Currently, DynamicPPL can't be tested with Distributions 0.24 due to AdvancedVI.