### PR TITLE
Add Enzyme support

### DIFF
--- a/src/compat/enzyme.jl
+++ b/src/compat/enzyme.jl
@@ -1,0 +1,5 @@
+struct EnzymeAD <: ADBackend end
+ADBackend(::Val{:enzyme}) = EnzymeAD
+function setadbackend(::Val{:enzyme})
+    ADBACKEND[] = :enzyme
+end


### PR DESCRIPTION
I wanted to add some very quick and rough support for Enzyme, to be able to avoid the hacks in the Turing.jl PR. I think the code is really not what one would want to use in the long term (probably should use AbstractDifferentiation/LogDensityProblemsAD/some Turing AD meta package).

@torfjelde I noticed that there are no tests of the AD backends at all currently? Maybe we should set them up for the existing backends first?