### PR TITLE
Use `Random.default_rng`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedVI"
 uuid = "b5ca4192-6429-45e5-a2d9-87aec30a685c"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"

--- a/src/AdvancedVI.jl
+++ b/src/AdvancedVI.jl
@@ -1,6 +1,6 @@
 module AdvancedVI
 
-using Random: AbstractRNG
+using Random: Random
 
 using Distributions, DistributionsAD, Bijectors
 using DocStringExtensions

--- a/src/advi.jl
+++ b/src/advi.jl
@@ -2,7 +2,6 @@ using StatsFuns
 using DistributionsAD
 using Bijectors
 using Bijectors: TransformedDistribution
-using Random: AbstractRNG, GLOBAL_RNG
 
 
 """
@@ -53,7 +52,7 @@ end
 
 # WITHOUT updating parameters inside ELBO
 function (elbo::ELBO)(
-    rng::AbstractRNG,
+    rng::Random.AbstractRNG,
     alg::ADVI,
     q::VariationalPosterior,
     logπ::Function,

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -1,9 +1,7 @@
-using Random: GLOBAL_RNG
-
 struct ELBO <: VariationalObjective end
 
 function (elbo::ELBO)(alg, q, logπ, num_samples; kwargs...)
-    return elbo(GLOBAL_RNG, alg, q, logπ, num_samples; kwargs...)
+    return elbo(Random.default_rng(), alg, q, logπ, num_samples; kwargs...)
 end
 
 const elbo = ELBO()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,5 @@
 using Distributions
 
-using Random: Random
 using Bijectors: Bijectors
 
 


### PR DESCRIPTION
`Random.GLOBAL_RNG` just exists for backwards compatibility but one should use `default_rng` nowadays.