### PR TITLE
Add SSH key for all relevant workflows

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs=["", "bench", "test", "docs"])'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
-        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs=["", "bench", "test", "docs"])'
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - name: Run doctests
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+.vscode/
+docs/build/
+.DS_Store
+Manifest.toml


### PR DESCRIPTION
This PR adds SSH keys for CompatHelper, Documenter, and TagBot workflows, so that they actually work properly.

(Context: https://github.com/TuringLang/Turing.jl/pull/2347 requires docs for AdvancedVI 0.2, and the lack of a SSH key here means that Documenter currently only generates 'dev' docs i.e. current master branch. ... Although I notice that AdvancedVI 0.2 has no docs, so this PR alone doesn't fully solve the problem. Once this is merged I'll follow up with a PR to the v0.2-backport branch.)

~~By the way, the buildkite integration hasn't ever passed on the master branch. I propose to also remove it.~~