### PR TITLE
Add minimal documentation for v0.2

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,18 @@
+using Documenter
+using AdvancedVI
+
+# Doctest setup
+DocMeta.setdocmeta!(AdvancedVI, :DocTestSetup, :(using AdvancedVI); recursive=true)
+
+makedocs(;
+    sitename="AdvancedVI",
+    modules=[AdvancedVI],
+    pages=[
+        "Home" => "index.md",
+        "API" => "api.md",
+    ],
+    checkdocs=:exports,
+    doctest=false,
+)
+
+deploydocs(; repo="github.com/TuringLang/AdvancedVI.jl.git", push_preview=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,12 +6,10 @@ DocMeta.setdocmeta!(AdvancedVI, :DocTestSetup, :(using AdvancedVI); recursive=tr
 
 makedocs(;
     sitename="AdvancedVI",
-    modules=[AdvancedVI],
     pages=[
         "Home" => "index.md",
         "API" => "api.md",
     ],
-    checkdocs=:exports,
     doctest=false,
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,6 @@
+## API
+
+```@docs
+vi
+ADVI
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,5 @@
+# AdvancedVI
+
+[AdvancedVI](https://github.com/TuringLang/AdvancedVI.jl) provides implementations of variational Bayesian inference (VI) algorithms.
+VI algorithms perform scalable and computationally efficient Bayesian inference at the cost of asymptotic exactness.
+`AdvancedVI` is part of the [Turing](https://turinglang.org/) probabilistic programming ecosystem.


### PR DESCRIPTION
Part of https://github.com/TuringLang/Turing.jl/pull/2347. Turing exposes `vi` and `ADVI` from v0.2, so this PR generates some docs for them.