### PR TITLE
Add compatibility for Bijectors 0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedVI"
 uuid = "b5ca4192-6429-45e5-a2d9-87aec30a685c"
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
This is a very small change to add compatibility with Bijectors 0.14.

The only code changes in Bijectors 0.14 are to do with its interactions with other packages, so AdvancedVI should not be affected at all.