### PR TITLE
Bulk-format with JuliaFormatter v1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,3 @@
-
 # Release 0.7
 
 ## Removal of special treatment to `Bijectors.TransformedDistribution`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ function LogDensityProblems.logdensity(model::LogReg, θ)
     logprior_β = logpdf(MvNormal(Zeros(d), σ), β)
     logprior_σ = logpdf(LogNormal(0, 3), σ)
 
-    logit = X*β
+    logit = X * β
     loglike_y = mapreduce((li, yi) -> logpdf(BernoulliLogit(li), yi), +, logit, y)
     return loglike_y + logprior_β + logprior_σ
 end
@@ -180,7 +180,7 @@ For the variational family, we will consider a `FullRankGaussian` approximation:
 using LinearAlgebra
 
 d = LogDensityProblems.dimension(prob_trans_ad)
-q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6*I, d, d)))
+q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6 * I, d, d)))
 q = MeanFieldGaussian(zeros(d), Diagonal(ones(d)));
 ```
 

--- a/docs/src/tutorials/basic.md
+++ b/docs/src/tutorials/basic.md
@@ -35,7 +35,7 @@ function LogDensityProblems.logdensity(model::LogReg, θ)
     logprior_β = logpdf(MvNormal(Zeros(d), σ), β)
     logprior_σ = logpdf(LogNormal(0, 3), σ)
 
-    logit = X*β
+    logit = X * β
     loglike_y = mapreduce((li, yi) -> logpdf(BernoulliLogit(li), yi), +, logit, y)
     return loglike_y + logprior_β + logprior_σ
 end
@@ -179,7 +179,7 @@ For the variational family, we will consider a `FullRankGaussian` approximation:
 using LinearAlgebra
 
 d = LogDensityProblems.dimension(prob_trans)
-q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6*I, d, d)))
+q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6 * I, d, d)))
 nothing
 ```
 
@@ -245,9 +245,9 @@ using StatsFuns: StatsFuns
 Approximate the posterior predictive probability for a logistic link function using Mackay's approximation (Bishop p. 220).
 """
 function logistic_prediction(X, μ_β, Σ_β)
-    xtΣx = sum((prob.X*Σ_β) .* prob.X; dims=2)[:, 1]
-    κ = @. 1/sqrt(1 + π/8*xtΣx)
-    return StatsFuns.logistic.(κ .* X*μ_β)
+    xtΣx = sum((prob.X * Σ_β) .* prob.X; dims=2)[:, 1]
+    κ = @. 1 / sqrt(1 + π / 8 * xtΣx)
+    return StatsFuns.logistic.(κ .* X * μ_β)
 end
 
 logging_interval = 100

--- a/docs/src/tutorials/constrained.md
+++ b/docs/src/tutorials/constrained.md
@@ -207,7 +207,7 @@ using AdvancedVI
 using LinearAlgebra
 
 d = LogDensityProblems.dimension(prob_trans_ad)
-q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6*I, d, d)))
+q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6 * I, d, d)))
 
 q_opt, info, _ = AdvancedVI.optimize(
     FisherMinBatchMatch(), 100, prob_trans_ad, q; show_progress=false
@@ -270,7 +270,7 @@ end
 LogDensityProblems.dimension(::MeanTransformed) = 2
 
 function LogDensityProblems.capabilities(::Type{MeanTransformed})
-    LogDensityProblems.LogDensityOrder{0}()
+    return LogDensityProblems.LogDensityOrder{0}()
 end
 
 n_data = 30

--- a/docs/src/tutorials/flows.md
+++ b/docs/src/tutorials/flows.md
@@ -158,7 +158,7 @@ using LinearAlgebra
 d = LogDensityProblems.dimension(prob_trans_ad)
 q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(I, d, d)))
 
-max_iter = 3*10^3
+max_iter = 3 * 10^3
 alg = KLMinRepGradProxDescent(ADTypes.AutoReverseDiff(; compile=true))
 q_out, info, _ = AdvancedVI.optimize(alg, max_iter, prob_trans_ad, q; show_progress=false)
 b = Bijectors.bijector(prob)

--- a/docs/src/tutorials/stan.md
+++ b/docs/src/tutorials/stan.md
@@ -84,7 +84,7 @@ using Plots
 alg = KLMinRepGradDescent(ADTypes.AutoReverseDiff(); operator=ClipScale())
 
 d = LogDensityProblems.dimension(model)
-q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.37*I, d, d)))
+q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.37 * I, d, d)))
 
 max_iter = 10^4
 q_out, info, _ = AdvancedVI.optimize(alg, max_iter, model, q; show_progress=false)

--- a/docs/src/tutorials/subsampling.md
+++ b/docs/src/tutorials/subsampling.md
@@ -32,9 +32,9 @@ function LogDensityProblems.logdensity(model::LogReg, θ)
     logprior_β = logpdf(MvNormal(Zeros(d), σ), β)
     logprior_σ = logpdf(Normal(0, 3), σ)
 
-    logit = X*β
+    logit = X * β
     loglike_y = mapreduce((li, yi) -> logpdf(BernoulliLogit(li), yi), +, logit, y)
-    return n_data/n*loglike_y + logprior_β + logprior_σ
+    return n_data / n * loglike_y + logprior_β + logprior_σ
 end
 
 function LogDensityProblems.dimension(model::LogReg)
@@ -158,7 +158,7 @@ The variational family will be set up as follows:
 using LinearAlgebra
 
 d = LogDensityProblems.dimension(prob_ad)
-q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6*I, d, d)))
+q = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6 * I, d, d)))
 nothing
 ```
 
@@ -177,9 +177,9 @@ time_begin = nothing
 Approximate the posterior predictive probability for a logistic link function using Mackay's approximation (Bishop p. 220).
 """
 function logistic_prediction(X, μ_β, Σ_β)
-    xtΣx = sum((prob.X*Σ_β) .* prob.X; dims=2)[:, 1]
-    κ = @. 1/sqrt(1 + π/8*xtΣx)
-    return StatsFuns.logistic.(κ .* X*μ_β)
+    xtΣx = sum((prob.X * Σ_β) .* prob.X; dims=2)[:, 1]
+    κ = @. 1 / sqrt(1 + π / 8 * xtΣx)
+    return StatsFuns.logistic.(κ .* X * μ_β)
 end
 
 function callback(; iteration, averaged_params, restructure, kwargs...)

--- a/src/AdvancedVI.jl
+++ b/src/AdvancedVI.jl
@@ -238,7 +238,7 @@ function step(
     objargs...;
     kwargs...,
 )
-    nothing
+    return nothing
 end
 
 """
@@ -276,11 +276,11 @@ Please refer to the respective documentation of each algorithm for more info.
 function estimate_objective(
     ::Random.AbstractRNG, ::AbstractVariationalAlgorithm, q, prob; kwargs...
 )
-    nothing
+    return nothing
 end
 
 function estimate_objective(alg::AbstractVariationalAlgorithm, q, prob; kwargs...)
-    estimate_objective(Random.default_rng(), alg, q, prob; kwargs...)
+    return estimate_objective(Random.default_rng(), alg, q, prob; kwargs...)
 end
 
 export estimate_objective

--- a/src/algorithms/abstractobjective.jl
+++ b/src/algorithms/abstractobjective.jl
@@ -31,7 +31,7 @@ function init(
     ::Any,
     ::Any,
 )
-    nothing
+    return nothing
 end
 
 """

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -116,5 +116,5 @@ function step(
         )
         info = !isnothing(info′) ? merge(info′, info) : info
     end
-    state, false, info
+    return state, false, info
 end

--- a/src/algorithms/fisherminbatchmatch.jl
+++ b/src/algorithms/fisherminbatchmatch.jl
@@ -89,14 +89,14 @@ function rand_batch_match_samples_with_objective!(
     μ = q.location
     C = q.scale
     u = Random.randn!(rng, u_buf)
-    z = C*u .+ μ
+    z = C * u .+ μ
     logπ_sum = zero(eltype(μ))
     for b in 1:n_samples
         logπb, gb = LogDensityProblems.logdensity_and_gradient(prob, view(z, :, b))
         grad_buf[:, b] = gb
         logπ_sum += logπb
     end
-    logπ_avg = logπ_sum/n_samples
+    logπ_avg = logπ_sum / n_samples
 
     # Estimate objective values
     #
@@ -105,7 +105,7 @@ function rand_batch_match_samples_with_objective!(
     #   = E[| C' ( -(CC')\((Cu + μ) - μ) - ∇logπ(z)) |^2] (z = Cu + μ)
     #   = E[| C' ( -(CC')\(Cu) - ∇logπ(z)) |^2]
     #   = E[| -u - C'∇logπ(z)) |^2]
-    fisher = sum(abs2, -u_buf - (C'*grad_buf))/n_samples
+    fisher = sum(abs2, -u_buf - (C' * grad_buf)) / n_samples
 
     return u_buf, z, grad_buf, fisher, logπ_avg
 end
@@ -145,13 +145,13 @@ function step(
     gbar, Γ = mean_and_cov(grad_buf, 2)
 
     μmz = μ - zbar
-    λ = convert(eltype(μ), d*n_samples / iteration)
+    λ = convert(eltype(μ), d * n_samples / iteration)
 
-    U = Symmetric(λ*Γ + (λ/(1 + λ)*gbar)*gbar')
-    V = Symmetric(Σ + λ*C + (λ/(1 + λ)*μmz)*μmz')
+    U = Symmetric(λ * Γ + (λ / (1 + λ) * gbar) * gbar')
+    V = Symmetric(Σ + λ * C + (λ / (1 + λ) * μmz) * μmz')
 
-    Σ′ = Hermitian(2*V/(I + real(sqrt(I + 4*U*V))))
-    μ′ = 1/(1 + λ)*μ + λ/(1 + λ)*(Σ′*gbar + zbar)
+    Σ′ = Hermitian(2 * V / (I + real(sqrt(I + 4 * U * V))))
+    μ′ = 1 / (1 + λ) * μ + λ / (1 + λ) * (Σ′ * gbar + zbar)
     q′ = MvLocationScale(μ′[:, 1], cholesky(Σ′).L, q.dist)
 
     elbo = logπ_avg + entropy(q)
@@ -163,7 +163,7 @@ function step(
         info′ = callback(; rng, iteration, q, state)
         info = !isnothing(info′) ? merge(info′, info) : info
     end
-    state, false, info
+    return state, false, info
 end
 
 """

--- a/src/algorithms/gauss_expected_grad_hess.jl
+++ b/src/algorithms/gauss_expected_grad_hess.jl
@@ -42,17 +42,17 @@ function gaussian_expectation_gradient_and_hessian!(
         d = LogDensityProblems.dimension(prob)
         u = randn(rng, T, d, n_samples)
         m, C = q.location, q.scale
-        z = C*u .+ m
+        z = C * u .+ m
         for b in 1:n_samples
             zb, ub = z[:, b], u[:, b]
             logπ, ∇logπ = LogDensityProblems.logdensity_and_gradient(prob, zb)
-            logπ_avg += logπ/n_samples
+            logπ_avg += logπ / n_samples
 
             rdiv!(∇logπ, n_samples)
             ∇logπ_div_nsamples = ∇logπ
 
             grad_buf[:] .+= ∇logπ_div_nsamples
-            hess_buf[:, :] .+= ub*∇logπ_div_nsamples'
+            hess_buf[:, :] .+= ub * ∇logπ_div_nsamples'
         end
         hess_buf[:, :] .= C' \ hess_buf
         return logπ_avg, grad_buf, hess_buf
@@ -71,7 +71,7 @@ function gaussian_expectation_gradient_and_hessian!(
             rdiv!(∇2logπ, n_samples)
             ∇2logπ_div_nsamples = ∇2logπ
 
-            logπ_avg += logπ/n_samples
+            logπ_avg += logπ / n_samples
             grad_buf[:] .+= ∇logπ_div_nsamples
             hess_buf[:, :] .+= ∇2logπ_div_nsamples
         end

--- a/src/algorithms/klminnaturalgraddescent.jl
+++ b/src/algorithms/klminnaturalgraddescent.jl
@@ -81,10 +81,10 @@ function init(
     grad_buf = Vector{eltype(q_init.location)}(undef, n_dims)
     hess_buf = Matrix{eltype(q_init.location)}(undef, n_dims, n_dims)
     scale = q_init.scale
-    qcov = Hermitian(scale*scale')
+    qcov = Hermitian(scale * scale')
     scale_inv = inv(scale)
     prec_chol = scale_inv'
-    prec = Hermitian(prec_chol*prec_chol')
+    prec = Hermitian(prec_chol * prec_chol')
     return KLMinNaturalGradDescentState(
         q_init, prob, prec, qcov, 0, sub_st, grad_buf, hess_buf
     )
@@ -127,7 +127,7 @@ function step(
         # Handling the positive-definite constraint in the Bayesian learning rule.
         # In ICML 2020.
         G_hat = S - (-hess_buf)
-        Hermitian(S - η*G_hat + η^2/2*G_hat*qcov*G_hat)
+        Hermitian(S - η * G_hat + η^2 / 2 * G_hat * qcov * G_hat)
     else
         Hermitian(((1 - η) * S + η * (-hess_buf)))
     end
@@ -136,7 +136,7 @@ function step(
     prec_chol = cholesky(S′).L
     prec_chol_inv = inv(prec_chol)
     scale = prec_chol_inv'
-    qcov = Hermitian(scale*scale')
+    qcov = Hermitian(scale * scale')
     q′ = MvLocationScale(m′, scale, q.dist)
 
     state = KLMinNaturalGradDescentState(
@@ -149,7 +149,7 @@ function step(
         info′ = callback(; rng, iteration, q=q′, info)
         info = !isnothing(info′) ? merge(info′, info) : info
     end
-    state, false, info
+    return state, false, info
 end
 
 """

--- a/src/algorithms/klminsqrtnaturalgraddescent.jl
+++ b/src/algorithms/klminsqrtnaturalgraddescent.jl
@@ -105,8 +105,8 @@ function step(
         rng, q, n_samples, grad_buf, hess_buf, prob_sub
     )
 
-    CtHCmI = C'*(-hess_buf)*C - I
-    CtHCmI_tril = LowerTriangular(tril(CtHCmI) - Diagonal(diag(CtHCmI))/2)
+    CtHCmI = C' * (-hess_buf) * C - I
+    CtHCmI_tril = LowerTriangular(tril(CtHCmI) - Diagonal(diag(CtHCmI)) / 2)
 
     m′ = m - η * C * (C' * -grad_buf)
     C′ = C - η * C * CtHCmI_tril
@@ -123,7 +123,7 @@ function step(
         info′ = callback(; rng, iteration, q=q′, info)
         info = !isnothing(info′) ? merge(info′, info) : info
     end
-    state, false, info
+    return state, false, info
 end
 
 """

--- a/src/algorithms/klminwassfwdbwd.jl
+++ b/src/algorithms/klminwassfwdbwd.jl
@@ -104,10 +104,10 @@ function step(
 
     m′ = m - η * (-grad_buf)
     M = I - η * (-hess_buf')
-    Σ_half = Hermitian(M*Σ*M')
+    Σ_half = Hermitian(M * Σ * M')
 
     # Compute the JKO proximal operator
-    Σ′ = (Σ_half + 2*η*I + sqrt(Hermitian(Σ_half*(Σ_half + 4*η*I))))/2
+    Σ′ = (Σ_half + 2 * η * I + sqrt(Hermitian(Σ_half * (Σ_half + 4 * η * I)))) / 2
     q′ = MvLocationScale(m′, cholesky(Σ′).L, q.dist)
 
     state = KLMinWassFwdBwdState(q′, prob, Σ′, iteration, sub_st′, grad_buf, hess_buf)
@@ -118,7 +118,7 @@ function step(
         info′ = callback(; rng, iteration, q=q′, info)
         info = !isnothing(info′) ? merge(info′, info) : info
     end
-    state, false, info
+    return state, false, info
 end
 
 """

--- a/src/optimization/rules.jl
+++ b/src/optimization/rules.jl
@@ -18,7 +18,9 @@ Optimisers.@def struct DoWG <: Optimisers.AbstractRule
     alpha = 1e-6
 end
 
-Optimisers.init(o::DoWG, x::AbstractArray{T}) where {T} = (copy(x), zero(T), T(o.alpha)*(1 + norm(x)))
+function Optimisers.init(o::DoWG, x::AbstractArray{T}) where {T}
+    return (copy(x), zero(T), T(o.alpha) * (1 + norm(x)))
+end
 
 function Optimisers.apply!(::DoWG, state, x::AbstractArray{T}, dx) where {T}
     x0, v, r = state
@@ -47,7 +49,9 @@ Optimisers.@def struct DoG <: Optimisers.AbstractRule
     alpha = 1e-6
 end
 
-Optimisers.init(o::DoG, x::AbstractArray{T}) where {T} = (copy(x), zero(T), T(o.alpha)*(1 + norm(x)))
+function Optimisers.init(o::DoG, x::AbstractArray{T}) where {T}
+    return (copy(x), zero(T), T(o.alpha) * (1 + norm(x)))
+end
 
 function Optimisers.apply!(::DoG, state, x::AbstractArray{T}, dx) where {T}
     x0, v, r = state

--- a/test/algorithms/fisherminbatchmatch.jl
+++ b/test/algorithms/fisherminbatchmatch.jl
@@ -22,7 +22,7 @@
             @test isfinite(obj_est)
 
             obj_est = estimate_objective(alg, q_true, model; n_samples=10^6)
-            @test obj_est ≈ 0 atol=1e-2
+            @test obj_est ≈ 0 atol = 1e-2
         end
 
         @testset "determinism" begin
@@ -86,7 +86,7 @@
         Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
         Δλ = sum(abs2, q_avg.location - μ_true) + sum(abs2, q_avg.scale - L_true)
 
-        @test Δλ ≤ Δλ0/2
+        @test Δλ ≤ Δλ0 / 2
     end
 
     @testset "subsampling" begin
@@ -136,7 +136,7 @@
             Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
             Δλ = sum(abs2, q.location - μ_true) + sum(abs2, q.scale - L_true)
 
-            @test Δλ ≤ Δλ0/2
+            @test Δλ ≤ Δλ0 / 2
         end
     end
 end

--- a/test/algorithms/klminnaturalgraddescent.jl
+++ b/test/algorithms/klminnaturalgraddescent.jl
@@ -22,7 +22,7 @@
             @test isfinite(obj_est)
 
             obj_est = estimate_objective(alg, q_true, model; n_samples=10^5)
-            @test obj_est ≈ 0 atol=1e-2
+            @test obj_est ≈ 0 atol = 1e-2
         end
 
         @testset "determinism" begin
@@ -86,7 +86,7 @@
         Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
         Δλ = sum(abs2, q_avg.location - μ_true) + sum(abs2, q_avg.scale - L_true)
 
-        @test Δλ ≤ 0.1*Δλ0
+        @test Δλ ≤ 0.1 * Δλ0
     end
 
     @testset "subsampling" begin
@@ -105,7 +105,7 @@
 
             obj_full = estimate_objective(alg, q0, model; n_samples=10^5)
             obj_sub = estimate_objective(alg_sub, q0, model; n_samples=10^5)
-            @test obj_full ≈ obj_sub rtol=0.1
+            @test obj_full ≈ obj_sub rtol = 0.1
         end
 
         @testset "determinism" begin
@@ -152,7 +152,7 @@
             Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
             Δλ = sum(abs2, q.location - μ_true) + sum(abs2, q.scale - L_true)
 
-            @test Δλ ≤ 0.1*Δλ0
+            @test Δλ ≤ 0.1 * Δλ0
         end
     end
 end

--- a/test/algorithms/klminrepgraddescent.jl
+++ b/test/algorithms/klminrepgraddescent.jl
@@ -34,7 +34,7 @@
             @test isfinite(obj_est)
 
             obj_est = estimate_objective(alg, q_true, model; n_samples=10^5)
-            @test obj_est ≈ 0 atol=1e-2
+            @test obj_est ≈ 0 atol = 1e-2
         end
 
         @testset "determinism" begin
@@ -117,7 +117,7 @@
         Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
         Δλ = sum(abs2, q_out.location - μ_true) + sum(abs2, q_out.scale - L_true)
 
-        @test Δλ ≤ Δλ0/2
+        @test Δλ ≤ Δλ0 / 2
     end
 
     @testset "subsampling" begin
@@ -137,7 +137,7 @@
 
             obj_full = estimate_objective(alg, q0, model; n_samples=10^5)
             obj_sub = estimate_objective(alg_sub, q0, model; n_samples=10^5)
-            @test obj_full ≈ obj_sub rtol=0.1
+            @test obj_full ≈ obj_sub rtol = 0.1
         end
 
         @testset "determinism" begin
@@ -189,7 +189,7 @@
             Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
             Δλ = sum(abs2, q.location - μ_true) + sum(abs2, q.scale - L_true)
 
-            @test Δλ ≤ Δλ0/2
+            @test Δλ ≤ Δλ0 / 2
         end
     end
 end

--- a/test/algorithms/klminrepgradproxdescent.jl
+++ b/test/algorithms/klminrepgradproxdescent.jl
@@ -34,7 +34,7 @@
             @test isfinite(obj_est)
 
             obj_est = estimate_objective(alg, q_true, model; n_samples=10^5)
-            @test obj_est ≈ 0 atol=1e-3
+            @test obj_est ≈ 0 atol = 1e-3
         end
 
         @testset "determinism" begin
@@ -88,7 +88,7 @@
         Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
         Δλ = sum(abs2, q_out.location - μ_true) + sum(abs2, q_out.scale - L_true)
 
-        @test Δλ ≤ Δλ0/2
+        @test Δλ ≤ Δλ0 / 2
     end
 
     @testset "subsampling" begin
@@ -107,7 +107,7 @@
 
             obj_full = estimate_objective(alg, q0, model; n_samples=10^5)
             obj_sub = estimate_objective(alg_sub, q0, model; n_samples=10^5)
-            @test obj_full ≈ obj_sub rtol=0.1
+            @test obj_full ≈ obj_sub rtol = 0.1
         end
 
         @testset "determinism" begin
@@ -155,7 +155,7 @@
             Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
             Δλ = sum(abs2, q.location - μ_true) + sum(abs2, q.scale - L_true)
 
-            @test Δλ ≤ Δλ0/2
+            @test Δλ ≤ Δλ0 / 2
         end
     end
 end

--- a/test/algorithms/klminscoregraddescent.jl
+++ b/test/algorithms/klminscoregraddescent.jl
@@ -34,7 +34,7 @@
             @test isfinite(obj_est)
 
             obj_est = estimate_objective(alg, q_true, model; n_samples=10^5)
-            @test obj_est ≈ 0 atol=1e-3
+            @test obj_est ≈ 0 atol = 1e-3
         end
 
         @testset "determinism" begin
@@ -93,7 +93,7 @@
         Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
         Δλ = sum(abs2, q_out.location - μ_true) + sum(abs2, q_out.scale - L_true)
 
-        @test Δλ ≤ Δλ0/2
+        @test Δλ ≤ Δλ0 / 2
     end
 
     @testset "subsampling" begin
@@ -113,7 +113,7 @@
 
             obj_full = estimate_objective(alg, q0, model; n_samples=10^5)
             obj_sub = estimate_objective(alg_sub, q0, model; n_samples=10^5)
-            @test obj_full ≈ obj_sub rtol=0.1
+            @test obj_full ≈ obj_sub rtol = 0.1
         end
 
         @testset "determinism" begin
@@ -165,7 +165,7 @@
             Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
             Δλ = sum(abs2, q.location - μ_true) + sum(abs2, q.scale - L_true)
 
-            @test Δλ ≤ Δλ0/2
+            @test Δλ ≤ Δλ0 / 2
         end
     end
 end

--- a/test/algorithms/klminsqrtnaturalgraddescent.jl
+++ b/test/algorithms/klminsqrtnaturalgraddescent.jl
@@ -22,7 +22,7 @@
             @test isfinite(obj_est)
 
             obj_est = estimate_objective(alg, q_true, model; n_samples=10^5)
-            @test obj_est ≈ 0 atol=1e-2
+            @test obj_est ≈ 0 atol = 1e-2
         end
 
         @testset "determinism" begin
@@ -86,7 +86,7 @@
         Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
         Δλ = sum(abs2, q_avg.location - μ_true) + sum(abs2, q_avg.scale - L_true)
 
-        @test Δλ ≤ 0.1*Δλ0
+        @test Δλ ≤ 0.1 * Δλ0
     end
 
     @testset "subsampling" begin
@@ -107,7 +107,7 @@
 
             obj_full = estimate_objective(alg, q0, model; n_samples=10^5)
             obj_sub = estimate_objective(alg_sub, q0, model; n_samples=10^5)
-            @test obj_full ≈ obj_sub rtol=0.1
+            @test obj_full ≈ obj_sub rtol = 0.1
         end
 
         @testset "determinism" begin
@@ -158,7 +158,7 @@
             Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
             Δλ = sum(abs2, q.location - μ_true) + sum(abs2, q.scale - L_true)
 
-            @test Δλ ≤ 0.1*Δλ0
+            @test Δλ ≤ 0.1 * Δλ0
         end
     end
 end

--- a/test/algorithms/klminwassfwdbwd.jl
+++ b/test/algorithms/klminwassfwdbwd.jl
@@ -22,7 +22,7 @@
             @test isfinite(obj_est)
 
             obj_est = estimate_objective(alg, q_true, model; n_samples=10^5)
-            @test obj_est ≈ 0 atol=1e-2
+            @test obj_est ≈ 0 atol = 1e-2
         end
 
         @testset "determinism" begin
@@ -86,7 +86,7 @@
         Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
         Δλ = sum(abs2, q_avg.location - μ_true) + sum(abs2, q_avg.scale - L_true)
 
-        @test Δλ ≤ Δλ0/2
+        @test Δλ ≤ Δλ0 / 2
     end
 
     @testset "subsampling" begin
@@ -105,7 +105,7 @@
 
             obj_full = estimate_objective(alg, q0, model; n_samples=10^5)
             obj_sub = estimate_objective(alg_sub, q0, model; n_samples=10^5)
-            @test obj_full ≈ obj_sub rtol=0.1
+            @test obj_full ≈ obj_sub rtol = 0.1
         end
 
         @testset "determinism" begin
@@ -152,7 +152,7 @@
             Δλ0 = sum(abs2, q0.location - μ_true) + sum(abs2, q0.scale - L_true)
             Δλ = sum(abs2, q.location - μ_true) + sum(abs2, q.scale - L_true)
 
-            @test Δλ ≤ Δλ0/2
+            @test Δλ ≤ Δλ0 / 2
         end
     end
 end

--- a/test/general/gauss_expected_grad_hess.jl
+++ b/test/general/gauss_expected_grad_hess.jl
@@ -6,12 +6,12 @@ end
 
 function LogDensityProblems.logdensity(model::TestQuad, x)
     Σ = model.Σ
-    return -x'*Σ*x/2
+    return -x' * Σ * x / 2
 end
 
 function LogDensityProblems.logdensity_and_gradient(model::TestQuad, x)
     Σ = model.Σ
-    return (LogDensityProblems.logdensity(model, x), -Σ*x)
+    return (LogDensityProblems.logdensity(model, x), -Σ * x)
 end
 
 function LogDensityProblems.logdensity_gradient_and_hessian(model::TestQuad, x)
@@ -36,7 +36,7 @@ end
 
     # True expected gradient is E_{x ~ N(μ, 1)} -Σ x = -Σ μ
     # True expected Hessian is E_{x ~ N(μ, 1)} -Σ = -Σ
-    E_∇ℓπ = -Σ*q.location
+    E_∇ℓπ = -Σ * q.location
     E_∇2ℓπ = -Σ
 
     @testset "$(cap)-order capability" for cap in [
@@ -48,7 +48,7 @@ end
         AdvancedVI.gaussian_expectation_gradient_and_hessian!(
             Random.default_rng(), q, n_samples, grad_buf, hess_buf, prob
         )
-        @test grad_buf ≈ E_∇ℓπ atol=1e-1
-        @test hess_buf ≈ E_∇2ℓπ atol=1e-1
+        @test grad_buf ≈ E_∇ℓπ atol = 1e-1
+        @test hess_buf ≈ E_∇2ℓπ atol = 1e-1
     end
 end

--- a/test/general/mixedad_logdensity.jl
+++ b/test/general/mixedad_logdensity.jl
@@ -28,7 +28,7 @@ function mixedad_test_fwd(x, prob)
     return (
         mean(Base.Fix1(LogDensityProblems.logdensity, prob), eachcol(xs)) +
         LogDensityProblems.logdensity(prob, x)
-    )/2
+    ) / 2
 end
 
 # MixedADLogDensityProblem only supports ReverseDiff, Enzyme, Mooncake in reverse-mode

--- a/test/general/subsampledobj.jl
+++ b/test/general/subsampledobj.jl
@@ -56,7 +56,7 @@
         sub_obj′ = SubsampledObjective(full_obj, sub)
         full_objval = estimate_objective(full_obj, q0, model; n_samples=10^8)
         sub_objval = estimate_objective(sub_obj′, q0, model; n_samples=10^8)
-        @test full_objval ≈ sub_objval rtol=0.1
+        @test full_objval ≈ sub_objval rtol = 0.1
     end
 
     @testset "estimate_gradient! batchsize=$(batchsize)" for batchsize in [1, 3, 4]

--- a/test/integration/dynamicppl.jl
+++ b/test/integration/dynamicppl.jl
@@ -1,7 +1,7 @@
 
 @testset "DynamicPPL" begin
     DynamicPPL.@model function normal(μ)
-        x ~ MvNormal(μ, I)
+        return x ~ MvNormal(μ, I)
     end
 
     DynamicPPL.@model function normal_subsampled(μs; datapoints=1:size(μs, 2))
@@ -22,18 +22,18 @@
 
         alg = KLMinRepGradProxDescent(AD)
         d = LogDensityProblems.dimension(prob)
-        q0 = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6*I, d, d)))
+        q0 = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6 * I, d, d)))
         q, _, _ = AdvancedVI.optimize(alg, 1000, prob, q0; show_progress=false)
 
         Δλ0 = sum(abs2, q0.location - μ_true)
         Δλ = sum(abs2, q.location - μ_true)
-        @test Δλ ≤ Δλ0/2
+        @test Δλ ≤ Δλ0 / 2
     end
 
     @testset "subsampling" begin
         n_data = 32
-        μs = 3*randn(2, n_data)
-        μ_true = mean(μs, dims=2)[:, 1]
+        μs = 3 * randn(2, n_data)
+        μ_true = mean(μs; dims=2)[:, 1]
 
         model = normal_subsampled(μs)
         vi = DynamicPPL.VarInfo(model)
@@ -48,11 +48,11 @@
 
         alg = KLMinRepGradProxDescent(AD; subsampling)
         d = LogDensityProblems.dimension(prob)
-        q0 = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6*I, d, d)))
+        q0 = FullRankGaussian(zeros(d), LowerTriangular(Matrix{Float64}(0.6 * I, d, d)))
         q, _, _ = AdvancedVI.optimize(alg, 1000, prob, q0; show_progress=false)
 
         Δλ0 = sum(abs2, q0.location - μ_true)
         Δλ = sum(abs2, q.location - μ_true)
-        @test Δλ ≤ Δλ0/2
+        @test Δλ ≤ Δλ0 / 2
     end
 end

--- a/test/models/subsamplednormals.jl
+++ b/test/models/subsamplednormals.jl
@@ -16,7 +16,7 @@ end
 
 function LogDensityProblems.logdensity(m::SubsampledNormals, x)
     (; likeadj, dists) = m
-    return likeadj*mapreduce(Base.Fix2(logpdf, only(x)), +, dists)
+    return likeadj * mapreduce(Base.Fix2(logpdf, only(x)), +, dists)
 end
 
 function LogDensityProblems.logdensity_and_gradient(m::SubsampledNormals, x)
@@ -44,7 +44,7 @@ end
 
 function AdvancedVI.subsample(m::SubsampledNormals, idx)
     n_data = length(m.dists)
-    return SubsampledNormals(m.dists[idx], n_data/length(idx), m.capability)
+    return SubsampledNormals(m.dists[idx], n_data / length(idx), m.capability)
 end
 
 function subsamplednormal(rng::Random.AbstractRNG, n_data::Int; capability::Int=1)
@@ -58,6 +58,6 @@ function subsamplednormal(rng::Random.AbstractRNG, n_data::Int; capability::Int=
     model = SubsampledNormals(rng, n_data, cap)
     n_dims = 1
     μ_true = [mean([mean(dist) for dist in model.dists])]
-    L_true = Diagonal([sqrt(1/n_data)])
+    L_true = Diagonal([sqrt(1 / n_data)])
     return TestModel(model, μ_true, L_true, n_dims, 1, true)
 end


### PR DESCRIPTION
Run JuliaFormatter v1 across the repository so the codebase matches the formatter the `TuringLang/actions/Format` CI action uses by default. Purely cosmetic: `return` keywords on function tails, spaces around binary operators, long-form `function … end` for over-long single-line definitions. No behaviour changes.